### PR TITLE
Fix: Prevent uvloop installation on Windows

### DIFF
--- a/requirements.lock
+++ b/requirements.lock
@@ -33,6 +33,5 @@ starlette==0.47.2
 typing-inspection==0.4.1
 typing_extensions==4.14.1
 uvicorn==0.35.0
-uvloop==0.21.0
 watchfiles==1.1.0
 websockets==15.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,6 +32,5 @@ starlette==0.47.2
 typing-inspection==0.4.1
 typing_extensions==4.14.1
 uvicorn==0.35.0
-uvloop==0.21.0
 watchfiles==1.1.0
 websockets==15.0.1

--- a/run.py
+++ b/run.py
@@ -1,9 +1,11 @@
 import uvicorn
+import sys
 
 if __name__ == "__main__":
     uvicorn.run(
         "app.main:app",
         host="127.0.0.1",
         port=8000,
-        reload=False
+        reload=False,
+        loop="asyncio" if sys.platform == "win32" else "auto"
     )


### PR DESCRIPTION
uvloop is not supported on Windows, which causes an error when installing dependencies.

This change addresses the issue by:
1. Removing `uvloop` from `requirements.txt` and `requirements.lock`.
2. Modifying `run.py` to conditionally set the event loop for uvicorn. On Windows, it explicitly uses `asyncio`. On other platforms, it uses `auto`, which will use `uvloop` if available.