### PR TITLE
Fix: Add missing route decorator for dashboard page

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -363,6 +363,7 @@ def approve_article(
 
     article_to_approve.status = "approved"
 
+@app.get("/dashboard", response_class=HTMLResponse)
 async def dashboard_page(request: Request, db: Session = Depends(get_db), user: models.User = Depends(security.get_current_active_user)):
 
     """


### PR DESCRIPTION
The dashboard page was returning a 404 Not Found error because the function `dashboard_page` in `app/main.py` was missing the FastAPI route decorator.

This commit adds the `@app.get("/dashboard", response_class=HTMLResponse)` decorator to the function, correctly registering it as a route.