### PR TITLE
Feat: Implement basic event creation feature

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -6,6 +6,7 @@ from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 import uvicorn
 from pathlib import Path
+from datetime import datetime
 
 import os
 from sqlalchemy.orm import Session
@@ -218,10 +219,36 @@ async def handle_edit_news(
 
     return RedirectResponse(url=f"/news/{news_id}", status_code=302)
 
-@api_router.post("/events")
-async def create_event():
-    """Placeholder for event creation logic (Admin only)."""
-    return {"message": "Event creation endpoint"}
+@api_router.post("/events", response_class=HTMLResponse)
+async def create_event(
+    title: str = Form(...),
+    description: str = Form(...),
+    date: str = Form(...),
+    location: str = Form(...),
+    db: Session = Depends(get_db),
+    current_user: models.User = Depends(security.require_role(["member", "manager"]))
+):
+    """Handles event creation from a logged-in user with member or manager role."""
+    try:
+        # The date is expected to be in YYYY-MM-DD format from the HTML form
+        event_date = datetime.strptime(date, "%Y-%m-%d")
+    except ValueError:
+        # Handle the case where the date format is incorrect
+        # You might want to return an error to the user
+        # For now, we'll raise an HTTPException
+        raise HTTPException(status_code=400, detail="Invalid date format. Please use YYYY-MM-DD.")
+
+    db_event = models.Event(
+        title=title,
+        description=description,
+        date=event_date,
+        location=location,
+        owner_id=current_user.id
+    )
+    db.add(db_event)
+    db.commit()
+    db.refresh(db_event)
+    return RedirectResponse(url="/events", status_code=302)
 
 
 
@@ -302,6 +329,15 @@ async def article_detail_page(request: Request, article_id: int, db: Session = D
     if not article:
         raise HTTPException(status_code=404, detail="Article not found")
     return templates.TemplateResponse("article_detail.html", {"request": request, "article": article})
+
+@app.get("/events/new", response_class=HTMLResponse)
+async def create_event_form(
+    request: Request,
+    current_user: models.User = Depends(security.require_role(["member", "manager"]))
+):
+    """Serves the page with a form to create a new event."""
+    return templates.TemplateResponse("create_event.html", {"request": request, "user": current_user})
+
 
 @app.get("/events", response_class=HTMLResponse)
 async def events_list_page(request: Request, db: Session = Depends(get_db)):

--- a/templates/create_event.html
+++ b/templates/create_event.html
@@ -1,0 +1,29 @@
+{% extends "base.html" %}
+
+{% block title %}Create New Event{% endblock %}
+
+{% block content %}
+<div class="container mt-5">
+    <h2>Create a New Event</h2>
+    <hr>
+    <form action="/api/v1/events" method="post" class="mt-4">
+        <div class="form-group mb-3">
+            <label for="title">Event Title</label>
+            <input type="text" class="form-control" id="title" name="title" required>
+        </div>
+        <div class="form-group mb-3">
+            <label for="description">Description</label>
+            <textarea class="form-control" id="description" name="description" rows="5" required></textarea>
+        </div>
+        <div class="form-group mb-3">
+            <label for="date">Event Date</label>
+            <input type="date" class="form-control" id="date" name="date" required>
+        </div>
+        <div class="form-group mb-3">
+            <label for="location">Location</label>
+            <input type="text" class="form-control" id="location" name="location" required>
+        </div>
+        <button type="submit" class="btn btn-primary">Create Event</button>
+    </form>
+</div>
+{% endblock %}

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -19,11 +19,6 @@
                     <li class="nav-item" role="presentation">
                         <button class="nav-link" id="news-tab" data-bs-toggle="tab" data-bs-target="#news" type="button" role="tab">ارسال خبر</button>
                     </li>
-                    {% if user.token_role == 'manager' %}
-                    <li class="nav-item" role="presentation">
-                        <button class="nav-link" id="event-tab" data-bs-toggle="tab" data-bs-target="#event" type="button" role="tab">ایجاد رویداد</button>
-                    </li>
-                    {% endif %}
                 </ul>
                 <div class="tab-content pt-3">
                     <div class="tab-pane active" id="article" role="tabpanel">
@@ -46,25 +41,25 @@
                             <button type="submit" class="btn btn-primary">ارسال خبر</button>
                         </form>
                     </div>
-                    {% if user.token_role == 'manager' %}
-                    <div class="tab-pane" id="event" role="tabpanel">
-                        <form action="/api/v1/events" method="post">
-                            <div class="mb-3"><label class="form-label">عنوان رویداد:</label><input type="text" name="title" class="form-control" required></div>
-                            <div class="mb-3"><label class="form-label">توضیحات:</label><textarea name="description" rows="3" class="form-control" required></textarea></div>
-                            <div class="mb-3"><label class="form-label">تاریخ:</label><input type="datetime-local" name="date" class="form-control" required></div>
-                            <div class="mb-3"><label class="form-label">مکان:</label><input type="text" name="location" class="form-control" required></div>
-                            <button type="submit" class="btn btn-primary">ایجاد رویداد</button>
-                        </form>
-                    </div>
-                    {% endif %}
                 </div>
+            </div>
+        </div>
+
+        <div class="card mt-4">
+            <div class="card-header">
+                مدیریت رویدادها
+            </div>
+            <div class="card-body">
+                {% if user.role == 'manager' or user.role == 'member' %}
+                <a href="/events/new" class="btn btn-primary">ایجاد رویداد جدید</a>
+                {% endif %}
             </div>
         </div>
     </div>
 
     <!-- Right Column: User Management -->
     <div class="col-md-4">
-        {% if user.token_role == 'manager' and user_list %}
+        {% if user.role == 'manager' and user_list %}
         <div class="card mb-4">
             <div class="card-header">
                 مدیریت کاربران
@@ -103,7 +98,7 @@
         </div>
         {% endif %}
 
-        {% if user.token_role == 'manager' and pending_articles %}
+        {% if user.role == 'manager' and pending_articles %}
         <div class="card">
             <div class="card-header">
                 مقالات در انتظار تأیید
@@ -129,7 +124,7 @@
 </div>
 
 <!-- Pending Content Section for Managers -->
-{% if user.token_role == 'manager' %}
+{% if user.role == 'manager' %}
 <div class="row mt-4">
     <!-- Pending Articles -->
     <div class="col-md-6">


### PR DESCRIPTION
This commit implements the basic functionality for creating events. The changes include:
- A new protected GET endpoint `/events/new` to serve the event creation form.
- A new protected POST endpoint `/api/v1/events` to handle the creation of new events.
- The protection ensures that only users with 'member' or 'manager' roles can create events.
- A new template `create_event.html` for the creation form.
- The `dashboard.html` template has been updated to remove an old, non-functional event form and now links to the new creation page for authorized users.
- All instances of `user.token_role` in the dashboard template have been corrected to `user.role` for consistency.