### PR TITLE
Fix: Ensure images are displayed on content pages

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -9,6 +9,9 @@
     {% for news in news_list %}
     <div class="col-md-4 mb-4">
         <div class="card h-100">
+            {% if news.image_url %}
+            <img src="{{ news.image_url }}" class="card-img-top" alt="{{ news.title }}" style="height: 200px; object-fit: cover;">
+            {% endif %}
             <div class="card-body">
                 <h5 class="card-title">{{ news.title }}</h5>
                 <p class="card-text">{{ news.summary }}</p>


### PR DESCRIPTION
This commit fixes an issue where images for news and events were not being displayed on the home page, list pages, or detail pages, even when an image URL was present in the database.

The `<img>` tag was missing from the `templates/index.html` file for the latest news section. This has been added.

Other templates (`news_list.html`, `news_detail.html`, `events_list.html`, `event_detail.html`) were also reviewed and confirmed to have the correct image display logic.