### PR TITLE
Feat: Implement event registration and capacity management

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -418,6 +418,52 @@ def reject_event(event_id: int, db: Session = Depends(get_db), current_user: mod
     return RedirectResponse(url="/dashboard", status_code=302)
 
 
+@api_router.post("/events/{event_id}/register", response_class=HTMLResponse)
+def register_for_event(
+    event_id: int,
+    db: Session = Depends(get_db),
+    current_user: models.User = Depends(security.get_current_active_user)
+):
+    """Registers the current user for an event."""
+    event = db.query(models.Event).filter(models.Event.id == event_id).first()
+    if not event:
+        raise HTTPException(status_code=404, detail="Event not found")
+
+    if event.registration_deadline and datetime.now(event.registration_deadline.tzinfo) > event.registration_deadline:
+        raise HTTPException(status_code=400, detail="Registration deadline has passed.")
+
+    if event.capacity and len(event.registrants) >= event.capacity:
+        raise HTTPException(status_code=400, detail="Event is full.")
+
+    if current_user in event.registrants:
+        raise HTTPException(status_code=400, detail="User is already registered for this event.")
+
+    event.registrants.append(current_user)
+    db.commit()
+
+    return RedirectResponse(url=f"/events/{event_id}", status_code=302)
+
+
+@api_router.post("/events/{event_id}/unregister", response_class=HTMLResponse)
+def unregister_from_event(
+    event_id: int,
+    db: Session = Depends(get_db),
+    current_user: models.User = Depends(security.get_current_active_user)
+):
+    """Unregisters the current user from an event."""
+    event = db.query(models.Event).filter(models.Event.id == event_id).first()
+    if not event:
+        raise HTTPException(status_code=404, detail="Event not found")
+
+    if current_user not in event.registrants:
+        raise HTTPException(status_code=400, detail="User is not registered for this event.")
+
+    event.registrants.remove(current_user)
+    db.commit()
+
+    return RedirectResponse(url=f"/events/{event_id}", status_code=302)
+
+
 app.include_router(api_router)
 
 from sqlalchemy.orm import joinedload
@@ -537,10 +583,21 @@ async def events_list_page(request: Request, db: Session = Depends(get_db), user
 @app.get("/events/{event_id}", response_class=HTMLResponse)
 async def event_detail_page(request: Request, event_id: int, db: Session = Depends(get_db), user: models.User = Depends(security.try_get_current_active_user)):
     """Serves the page for a single event."""
-    event = db.query(models.Event).options(joinedload(models.Event.owner)).filter(models.Event.id == event_id, models.Event.status == "approved").first()
+    event = db.query(models.Event).options(joinedload(models.Event.owner), joinedload(models.Event.registrants)).filter(models.Event.id == event_id, models.Event.status == "approved").first()
     if not event:
         raise HTTPException(status_code=404, detail="Event not found")
-    return templates.TemplateResponse("event_detail.html", {"request": request, "event": event, "user": user})
+
+    deadline_passed = False
+    if event.registration_deadline:
+        # Make sure 'now' is timezone-aware if the deadline is
+        deadline_passed = datetime.now(event.registration_deadline.tzinfo) > event.registration_deadline
+
+    return templates.TemplateResponse("event_detail.html", {
+        "request": request,
+        "event": event,
+        "user": user,
+        "deadline_passed": deadline_passed
+    })
 
 # --- Admin/Manager Specific Endpoints ---
 

--- a/app/models.py
+++ b/app/models.py
@@ -1,8 +1,13 @@
-from sqlalchemy import Boolean, Column, DateTime, ForeignKey, Integer, String, Text
+from sqlalchemy import Boolean, Column, DateTime, ForeignKey, Integer, String, Text, Table
 from sqlalchemy.sql import func
 from sqlalchemy.orm import relationship
 
 from .database import Base
+
+event_registration = Table('event_registration', Base.metadata,
+    Column('user_id', Integer, ForeignKey('users.id'), primary_key=True),
+    Column('event_id', Integer, ForeignKey('events.id'), primary_key=True)
+)
 
 class User(Base):
     __tablename__ = "users"
@@ -15,6 +20,8 @@ class User(Base):
 
     articles = relationship("Article", back_populates="owner")
     news = relationship("News", back_populates="owner")
+    created_events = relationship("Event", back_populates="owner")
+    registered_events = relationship("Event", secondary=event_registration, back_populates="registrants")
 
 class Article(Base):
     __tablename__ = "articles"
@@ -66,4 +73,5 @@ class Event(Base):
     created_at = Column(DateTime(timezone=True), server_default=func.now())
     owner_id = Column(Integer, ForeignKey("users.id"))
 
-    owner = relationship("User")
+    owner = relationship("User", back_populates="created_events")
+    registrants = relationship("User", secondary=event_registration, back_populates="registered_events")

--- a/templates/event_detail.html
+++ b/templates/event_detail.html
@@ -32,7 +32,13 @@
                     <li class="list-group-item"><strong>پایان:</strong> {{ event.end_time.strftime('%Y-%m-%d %H:%M') }}</li>
                     {% endif %}
                     {% if event.capacity %}
-                    <li class="list-group-item"><strong>ظرفیت:</strong> {{ event.capacity }} نفر</li>
+                    <li class="list-group-item">
+                        <strong>ظرفیت:</strong>
+                        {{ event.registrants|length }} / {{ event.capacity }} نفر
+                        <div class="progress mt-1">
+                            <div class="progress-bar" role="progressbar" style="width: {{ (event.registrants|length / event.capacity) * 100 }}%;" aria-valuenow="{{ event.registrants|length }}" aria-valuemin="0" aria-valuemax="{{ event.capacity }}"></div>
+                        </div>
+                    </li>
                     {% endif %}
                     {% if event.registration_deadline %}
                     <li class="list-group-item"><strong>آخرین مهلت ثبت نام:</strong> {{ event.registration_deadline.strftime('%Y-%m-%d %H:%M') }}</li>
@@ -40,10 +46,24 @@
                      <li class="list-group-item"><strong>ایجاد کننده:</strong> {{ event.owner.username }}</li>
                 </ul>
                 <div class="card-body">
-                    <!-- Action Buttons -->
+                    <!-- Registration Buttons -->
                     {% if user %}
-                        {# Future button for registration could go here #}
-                        {# <a href="#" class="btn btn-success w-100">ثبت نام</a> #}
+                        {% set is_registered = user in event.registrants %}
+                        {% set is_full = event.capacity and event.registrants|length >= event.capacity %}
+
+                        {% if is_registered %}
+                            <form action="/api/v1/events/{{ event.id }}/unregister" method="post">
+                                <button type="submit" class="btn btn-danger w-100">لغو ثبت نام</button>
+                            </form>
+                        {% elif is_full %}
+                            <button class="btn btn-secondary w-100" disabled>ظرفیت تکمیل است</button>
+                        {% elif deadline_passed %}
+                             <button class="btn btn-secondary w-100" disabled>مهلت ثبت نام تمام شده</button>
+                        {% else %}
+                            <form action="/api/v1/events/{{ event.id }}/register" method="post">
+                                <button type="submit" class="btn btn-success w-100">ثبت نام</button>
+                            </form>
+                        {% endif %}
                     {% else %}
                         <a href="/login" class="btn btn-primary w-100">برای ثبت نام وارد شوید</a>
                     {% endif %}
@@ -62,6 +82,22 @@
                         <button type="submit" class="btn btn-danger w-100">حذف رویداد</button>
                     </form>
                 </div>
+            </div>
+            {% endif %}
+
+            <!-- Registrants List for Managers -->
+            {% if user and user.role == 'manager' %}
+            <div class="card mt-4">
+                <div class="card-header">
+                    <h4>لیست ثبت نام شدگان</h4>
+                </div>
+                <ul class="list-group list-group-flush">
+                    {% for registrant in event.registrants %}
+                        <li class="list-group-item">{{ registrant.username }} ({{ registrant.email }})</li>
+                    {% else %}
+                        <li class="list-group-item">هنوز کسی ثبت نام نکرده است.</li>
+                    {% endfor %}
+                </ul>
             </div>
             {% endif %}
         </div>


### PR DESCRIPTION
This commit introduces a full feature for you to register for events, and for event creators to manage capacity.

Key changes:
- **Database Model:** A many-to-many relationship between Users and Events has been created via a new `event_registration` association table. This tracks who is registered for which events.
- **Registration Endpoints:** New endpoints have been added to handle event registration (`/api/v1/events/{event_id}/register`) and cancellation (`/api/v1/events/{event_id}/unregister`).
- **Business Logic:** The registration endpoint includes logic to check for event capacity, registration deadlines, and prevent duplicate registrations.
- **Frontend UI:** The `event_detail.html` template has been significantly updated to display:
    - The number of registered attendees and the event capacity.
    - A progress bar showing how full the event is.
    - Conditional buttons for "Register" or "Cancel Registration" based on your registration status.
    - A list of registered attendees, visible only to managers.