### PR TITLE
Feat: Allow managers to delete published articles

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -394,6 +394,26 @@ def reject_article(article_id: int, db: Session = Depends(get_db), current_user:
     return RedirectResponse(url="/dashboard", status_code=302)
 
 
+@api_router.post("/articles/{article_id}/delete", response_class=HTMLResponse)
+def delete_article(
+    article_id: int,
+    db: Session = Depends(get_db),
+    current_user: models.User = Depends(security.require_role(["manager"]))
+):
+    """Deletes an article. For managers only."""
+    article_to_delete = db.query(models.Article).filter(models.Article.id == article_id).first()
+    if not article_to_delete:
+        raise HTTPException(status_code=404, detail="Article not found")
+
+    # Also delete the associated file from the server
+    if article_to_delete.file_path and os.path.exists(article_to_delete.file_path):
+        os.remove(article_to_delete.file_path)
+
+    db.delete(article_to_delete)
+    db.commit()
+    return RedirectResponse(url="/articles", status_code=302)
+
+
 @api_router.post("/events/{event_id}/approve", response_class=HTMLResponse)
 def approve_event(event_id: int, db: Session = Depends(get_db), current_user: models.User = Depends(security.require_role(["manager"]))):
     """Approves an event, setting its 'status' to 'approved'."""
@@ -535,12 +555,12 @@ async def articles_list_page(request: Request, db: Session = Depends(get_db)):
     return templates.TemplateResponse("articles_list.html", {"request": request, "articles_list": articles})
 
 @app.get("/articles/{article_id}", response_class=HTMLResponse)
-async def article_detail_page(request: Request, article_id: int, db: Session = Depends(get_db)):
+async def article_detail_page(request: Request, article_id: int, db: Session = Depends(get_db), user: models.User = Depends(security.try_get_current_active_user)):
     """Serves the page for a single article."""
     article = db.query(models.Article).options(joinedload(models.Article.owner)).filter(models.Article.id == article_id, models.Article.status == "approved").first()
     if not article:
         raise HTTPException(status_code=404, detail="Article not found")
-    return templates.TemplateResponse("article_detail.html", {"request": request, "article": article})
+    return templates.TemplateResponse("article_detail.html", {"request": request, "article": article, "user": user})
 
 @app.get("/events/new", response_class=HTMLResponse)
 async def create_event_form(

--- a/templates/article_detail.html
+++ b/templates/article_detail.html
@@ -16,7 +16,15 @@
         </div>
         <hr>
         <p>{{ article.content }}</p>
-        <a href="/articles" class="btn btn-secondary mt-3">بازگشت به لیست مقالات</a>
+        <hr>
+        <div class="d-flex justify-content-between align-items-center">
+            <a href="/articles" class="btn btn-secondary mt-3">بازگشت به لیست مقالات</a>
+            {% if user and user.role == 'manager' %}
+            <form action="/api/v1/articles/{{ article.id }}/delete" method="post" onsubmit="return confirm('آیا از حذف این مقاله مطمئن هستید؟');">
+                <button type="submit" class="btn btn-danger mt-3">حذف مقاله</button>
+            </form>
+            {% endif %}
+        </div>
     </div>
 </div>
 {% endblock %}


### PR DESCRIPTION
This commit adds the functionality for users with the 'manager' role to delete any article, regardless of its status or owner.

Key changes:
- A new endpoint, `POST /api/v1/articles/{article_id}/delete`, has been created and is protected to be accessible only by managers.
- The endpoint's logic deletes the specified article from the database and also removes the associated file from the server's `uploads` directory if it exists.
- A "Delete" button has been added to the `article_detail.html` template, which is only visible to managers.
- The `article_detail_page` endpoint has been updated to pass the `user` object to its template to enable this conditional rendering.